### PR TITLE
usrp2: Fix DC truncation bias by adding rounding to USRP2 DDC chain.

### DIFF
--- a/usrp2/sdr_lib/hb_dec.v
+++ b/usrp2/sdr_lib/hb_dec.v
@@ -34,7 +34,7 @@ module hb_dec
      output reg [WIDTH-1:0] data_out);
 
    localparam INTWIDTH = 17;
-   localparam ACCWIDTH = WIDTH + 3;
+   localparam ACCWIDTH = 30;
    
    // Round off inputs to 17 bits because of 18 bit multipliers
    wire [INTWIDTH-1:0] 	     data_rnd;
@@ -159,23 +159,28 @@ module hb_dec
 
    reg [35:0] 	     sum_of_prod;
    always @(posedge clk) sum_of_prod <= prod1 + prod2;   // Can't overflow
-   
-   wire [ACCWIDTH-1:0] 	acc_out;
-   acc #(.IWIDTH(ACCWIDTH-2),.OWIDTH(ACCWIDTH))
-     acc (.clk(clk),.clear(clear),.acc(do_acc),.in(sum_of_prod[35:38-ACCWIDTH]),.out(acc_out));
 
-   wire [ACCWIDTH-1:0] 	data_even_signext;
+   wire [35:0]  acc_out;
+   acc #(.IWIDTH(36),.OWIDTH(36))
+     acc (.clk(clk),.clear(clear),.acc(do_acc),.in(sum_of_prod),.out(acc_out));
 
-   localparam SHIFT_FACTOR = 6;
-   
-   sign_extend #(.bits_in(INTWIDTH),.bits_out(ACCWIDTH-SHIFT_FACTOR)) signext_data_even 
-     (.in(data_even),.out(data_even_signext[ACCWIDTH-1:SHIFT_FACTOR]));
-   assign 		data_even_signext[SHIFT_FACTOR-1:0] = 0;
+   wire [WIDTH:0] acc_out_rnd;
+   round #(.bits_in(36),.bits_out(WIDTH+1)) round_acc
+     (.in(acc_out), .out(acc_out_rnd));
 
-   always @(posedge clk) final_sum <= acc_out + data_even_signext;
-   
-   clip #(.bits_in(WIDTH+1), .bits_out(WIDTH)) clip (.in(final_sum), .out(final_sum_clip));
-   
+   wire [WIDTH:0]     data_even_signext;
+
+   localparam SHIFT_FACTOR = 17 - (36 - (WIDTH+1));
+
+   sign_extend #(.bits_in(INTWIDTH),.bits_out(WIDTH+1-SHIFT_FACTOR)) signext_data_even
+     (.in(data_even),.out(data_even_signext[WIDTH:SHIFT_FACTOR]));
+   assign       data_even_signext[SHIFT_FACTOR-1:0] = 0;
+
+   always @(posedge clk) final_sum <= acc_out_rnd + data_even_signext;
+
+   clip #(.bits_in(WIDTH+1),.bits_out(WIDTH)) clip_finalsum
+     (.in(final_sum), .out(final_sum_clip));
+
    // Output MUX to allow for bypass
    wire 		selected_stb = bypass ? stb_in : stb_out_pre[8];
    

--- a/usrp2/sdr_lib/small_hb_dec.v
+++ b/usrp2/sdr_lib/small_hb_dec.v
@@ -107,13 +107,18 @@ module small_hb_dec
    localparam ACCWIDTH = 30;
    reg [ACCWIDTH-1:0] 	 accum;
    
+   wire [ACCWIDTH-1:0] prod_acc_rnd;
+   round #(.bits_in(36),.bits_out(ACCWIDTH),
+           .round_to_zero(1),.round_to_nearest(0),.trunc(0)) round_prod
+     (.in(prod), .out(prod_acc_rnd));
+
    always @(posedge clk)
      if(rst)
        accum <= 0;
      else if(go_d2)
-       accum <= {middle_d1[17],middle_d1[17],middle_d1,{(16+ACCWIDTH-36){1'b0}}} + {prod[35:36-ACCWIDTH]};
+       accum <= {middle_d1[17],middle_d1[17],middle_d1,{(16+ACCWIDTH-36){1'b0}}} + prod_acc_rnd;
      else if(go_d3)
-       accum <= accum + {prod[35:36-ACCWIDTH]};
+       accum <= accum + prod_acc_rnd;
    
    wire [WIDTH:0] 	 accum_rnd;
    wire [WIDTH-1:0] 	 accum_rnd_clip;


### PR DESCRIPTION
Currently, the USRP2 DDC code truncates to 18 bits from 24 bits after applying the halfband filters and before applying a scaling and final rounding. This truncation introduces a DC bias that is noticeable when signal levels are low. Changing the truncation to a rounding removes the DC bias.

The effect can be seen in the attached figure. I ran two N200s with BasicRX boards in dual-channel mode simultaneously without signal input using a decimation factor of 24. The top two spectra are from the N200 using a firmware with this patch applied, and the bottom two spectra are from the N200 using the stock firmware. A DC signal is clearly visible when using the stock firmware, and it disappears when using this patch. (The non-DC spike is spurious and particular to that receiver, and it is not affected by the patch.)
![usrp_n200_firmware_comparison](https://cloud.githubusercontent.com/assets/4391207/11350845/8dbfd7f6-9201-11e5-9002-6159fd2fe956.png)

The DC bias is something that I saw routinely when using the BasicRX board and viewing low-SNR signals. I believe it is also more noticeable with higher decimation rates, but I haven't tested it fully. It's not a huge issue, but I was motivated to track down the cause and the fix ended up being simple enough.

A quick perusal of the source also shows that a similar truncation may be an issue with the DDC chains for other USRP firmwares.
