### PR TITLE
usrp2: Include variable bit gain set by register after CIC filter

### DIFF
--- a/usrp2/sdr_lib/Makefile.srcs
+++ b/usrp2/sdr_lib/Makefile.srcs
@@ -40,6 +40,7 @@ sign_extend.v \
 small_hb_dec.v \
 small_hb_int.v \
 tx_frontend.v \
+variable_part_select_and_clip.v \
 dsp_tx_glue.v \
 dsp_rx_glue.v \
 ))

--- a/usrp2/sdr_lib/round.v
+++ b/usrp2/sdr_lib/round.v
@@ -39,8 +39,8 @@ module round
    assign 			 round_corr_nearest = in[bits_in-bits_out-1];
 
    generate
-      if(bits_in-bits_out > 1)
-	assign 			 round_corr_nearest_safe = (~in[bits_in-1] & (&in[bits_in-2:bits_out])) ? 0 :
+      if(bits_out > 1)
+	assign 			 round_corr_nearest_safe = (~in[bits_in-1] & (&in[bits_in-2:bits_in-bits_out])) ? 0 :
 				 round_corr_nearest;
       else
 	assign round_corr_nearest_safe = round_corr_nearest;

--- a/usrp2/sdr_lib/small_hb_dec.v
+++ b/usrp2/sdr_lib/small_hb_dec.v
@@ -120,15 +120,16 @@ module small_hb_dec
      else if(go_d3)
        accum <= accum + prod_acc_rnd;
    
-   wire [WIDTH:0] 	 accum_rnd;
+   wire [ACCWIDTH-2:0] 	 accum_clip;
    wire [WIDTH-1:0] 	 accum_rnd_clip;
    
    wire 	 stb_round;
    
-   round_sd #(.WIDTH_IN(ACCWIDTH),.WIDTH_OUT(WIDTH+1)) round_acc 
-     (.clk(clk), .reset(rst), .in(accum), .strobe_in(go_d4), .out(accum_rnd), .strobe_out(stb_round));
+   clip #(.bits_in(ACCWIDTH),.bits_out(ACCWIDTH-1)) clip (.in(accum), .out(accum_clip));
 
-   clip #(.bits_in(WIDTH+1),.bits_out(WIDTH)) clip (.in(accum_rnd), .out(accum_rnd_clip));
+   round_sd #(.WIDTH_IN(ACCWIDTH-1),.WIDTH_OUT(WIDTH)) round_acc
+     (.clk(clk), .reset(rst), .in(accum_clip), .strobe_in(go_d4), .out(accum_rnd_clip), .strobe_out(stb_round));
+
    
    // Output
    always @(posedge clk)

--- a/usrp2/sdr_lib/variable_part_select_and_clip.v
+++ b/usrp2/sdr_lib/variable_part_select_and_clip.v
@@ -1,0 +1,75 @@
+// -*- verilog -*-
+//
+//  USRP - Universal Software Radio Peripheral
+//
+//  Copyright (C) 2016 Ryan Volz
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin Street, Boston, MA  02110-1301  USA
+//
+
+
+module variable_part_select_and_clip
+  #(parameter WIDTH_IN=31, WIDTH_OUT=24, INDEX_WIDTH=3)
+    (input clk,
+     input strobe_in,
+     output reg strobe_out,
+     input [WIDTH_IN-1:0] signal_in,
+     input [INDEX_WIDTH-1:0] lowidx,
+     output reg [WIDTH_OUT-1:0] signal_out);
+
+   localparam MASKBW = WIDTH_IN - WIDTH_OUT;
+
+   // isolate bits to be clipped and determine if an overflow would occur
+   wire [MASKBW:0] head = signal_in[WIDTH_IN-1 -: MASKBW+1];
+
+   // bit order reversed so we can read in reverse
+   reg [0:MASKBW+MASKBW-1] maskrom = {{MASKBW{1'b1}}, {MASKBW{1'b0}}};
+
+   function [MASKBW-1:0] clipmask;
+      input [INDEX_WIDTH-1:0] idx;
+      clipmask = maskrom[MASKBW-1+idx -: MASKBW];
+// with MASKBW == 7 and INDEX_WIDTH ==3, this is equivalent to the following:
+//    case(idx)
+//      3'd0 : clipmask = 7'b1111111;
+//      3'd1 : clipmask = 7'b1111110;
+//      3'd2 : clipmask = 7'b1111100;
+//      3'd3 : clipmask = 7'b1111000;
+//      3'd4 : clipmask = 7'b1110000;
+//      3'd5 : clipmask = 7'b1100000;
+//      3'd6 : clipmask = 7'b1000000;
+//      default : clipmask = 7'b0000000;
+//    endcase
+   endfunction
+
+   // use register for mask to limit delay
+   reg [MASKBW-1:0] mask;
+   always @(posedge clk)
+     mask <= clipmask(lowidx);
+
+   wire overflow = |((head[MASKBW-1:0] ^ {MASKBW{head[MASKBW]}}) & mask);
+
+   // apply part selection and clip if necessary
+   wire [WIDTH_OUT-1:0] clipped = signal_in[WIDTH_IN-1] ?
+                                    {1'b1, {(WIDTH_OUT-1){1'b0}}} :
+                                    {1'b0, {(WIDTH_OUT-1){1'b1}}};
+
+   wire [WIDTH_OUT-1:0] signal_selected = signal_in[lowidx +: WIDTH_OUT];
+
+   always @(posedge clk) begin
+     signal_out <= overflow ? clipped : signal_selected;
+     strobe_out <= strobe_in;
+   end
+
+endmodule // variable_part_select_and_clip


### PR DESCRIPTION
Decimation by N creates a possible log2(N)/2 bits of additional precision. Currently, this extra precision is lost in the DDC chain by internal conversions down to 17-18 bits from 24 bits for multiplication. This patch inserts a variable bit gain after the CIC filter and before any of the decimation precision is lost, allowing that precision to be kept at the expense of higher order bits. When the signal levels are low enough so that the higher order bits are not used, this is a great tradeoff to make.

Using this requires a change to the UHD host code to specify the bit gain.

This feature has been useful in our work, and we thought there might be some upstream interest as well.
