### PR TITLE
fft_shift.v: Fixed fft size edge cases

### DIFF
--- a/usrp3_rfnoc/lib/rfnoc/fft_shift.v
+++ b/usrp3_rfnoc/lib/rfnoc/fft_shift.v
@@ -12,7 +12,7 @@ module fft_shift #(
   parameter WIDTH = 32)
 (
   input clk, input reset,
-  input [$clog2(MAX_FFT_SIZE_LOG2)-1:0] fft_size_log2_tdata, input fft_size_log2_tvalid, output fft_size_log2_tready,
+  input [$clog2(MAX_FFT_SIZE_LOG2+1)-1:0] fft_size_log2_tdata, input fft_size_log2_tvalid, output fft_size_log2_tready,
   input [WIDTH-1:0] i_tdata, input i_tlast, input i_tvalid, output i_tready, input [MAX_FFT_SIZE_LOG2-1:0] i_tuser,
   output [WIDTH-1:0] o_tdata, output o_tlast, output o_tvalid, input o_tready
 );
@@ -20,8 +20,9 @@ module fft_shift #(
   reg ping_pong;
   reg loading_pkt;
   reg [2:0] reconfig_stall;
-  reg [$clog2(MAX_FFT_SIZE_LOG2)-1:0] fft_size_log2_latch;
-  reg [MAX_FFT_SIZE_LOG2-1:0] fft_size, fft_size_minus_1, fft_shift_mask;
+  reg [$clog2(MAX_FFT_SIZE_LOG2+1)-1:0] fft_size_log2_latch;
+  reg [MAX_FFT_SIZE_LOG2:0] fft_size;
+  reg [MAX_FFT_SIZE_LOG2-1:0] fft_size_minus_1, fft_shift_mask;
   wire [WIDTH-1:0] ping_rd_data, pong_rd_data;
   reg [MAX_FFT_SIZE_LOG2-1:0] ping_rd_addr, pong_rd_addr;
   // t_user is the FFT index, this XOR is how the natural order FFT output is flipped to

--- a/usrp3_rfnoc/lib/rfnoc/noc_block_fft.v
+++ b/usrp3_rfnoc/lib/rfnoc/noc_block_fft.v
@@ -166,9 +166,9 @@ module noc_block_fft #(
     .clk(ce_clk), .rst(ce_rst),
     .strobe(set_stb), .addr(set_addr), .in(set_data), .out(fft_reset), .changed());
 
-  wire [$clog2(MAX_FFT_SIZE_LOG2)-1:0] fft_size_log2_tdata;
+  wire [$clog2(MAX_FFT_SIZE_LOG2+1)-1:0] fft_size_log2_tdata;
   axi_setting_reg #(
-    .ADDR(SR_FFT_SIZE_LOG2), .AWIDTH(8), .WIDTH($clog2(MAX_FFT_SIZE_LOG2)))
+    .ADDR(SR_FFT_SIZE_LOG2), .AWIDTH(8), .WIDTH($clog2(MAX_FFT_SIZE_LOG2+1)))
   sr_fft_size_log2 (
     .clk(ce_clk), .reset(ce_rst), .error_stb(),
     .set_stb(set_stb), .set_addr(set_addr), .set_data(set_data),


### PR DESCRIPTION
Fixed fft size edge cases in fft_shift.v where the MAX_FFT_SIZE_LOG2 is handled incorrectly.
1. If the fft_size_log2_tdata is equal to 2^MAX_FFT_SIZE_LOG2, the fft_size register needs an extra bit.
2. If MAX_FFT_SIZE_LOG2 is a power of 2, the input fft_size_log2_tdata needs an extra bit