### PR TITLE
addsub_hls: Modified testbench to build and use HLS ip

### DIFF
--- a/usrp3/lib/hls/addsub_hls/addsub_hls.cpp
+++ b/usrp3/lib/hls/addsub_hls/addsub_hls.cpp
@@ -13,10 +13,10 @@ void addsub_hls (axis_cplx &a, axis_cplx &b, axis_cplx &add, axis_cplx &sub) {
     // Remove ap ctrl ports (ap_start, ap_ready, ap_idle, etc) since we only use the AXI-Stream ports
     #pragma HLS INTERFACE ap_ctrl_none port=return
     // Set ports as AXI-Stream
-    #pragma HLS INTERFACE axis register port=sub
-    #pragma HLS INTERFACE axis register port=add
-    #pragma HLS INTERFACE axis register port=a
-    #pragma HLS INTERFACE axis register port=b
+    #pragma HLS INTERFACE axis port=sub
+    #pragma HLS INTERFACE axis port=add
+    #pragma HLS INTERFACE axis port=a
+    #pragma HLS INTERFACE axis port=b
     // Need to pack our complex<short int> into a 32-bit word
     // Otherwise, compiler complains that our AXI-Stream interfaces have two data fields (i.e. data.real, data.imag)
     #pragma HLS DATA_PACK variable=sub.data
@@ -25,8 +25,10 @@ void addsub_hls (axis_cplx &a, axis_cplx &b, axis_cplx &add, axis_cplx &sub) {
     #pragma HLS DATA_PACK variable=b.data
 
     // Complex add / subtract
-    add.data = a.data + b.data;
-    sub.data = a.data - b.data;
+    add.data.real() = a.data.real() + b.data.real();
+    add.data.imag() = a.data.imag() + b.data.imag();
+    sub.data.real() = a.data.real() - b.data.real();
+    sub.data.imag() = a.data.imag() - b.data.imag();
     // Pass through tlast
     add.last = a.last;
     sub.last = a.last;

--- a/usrp3/lib/rfnoc/noc_block_addsub_tb/Makefile
+++ b/usrp3/lib/rfnoc/noc_block_addsub_tb/Makefile
@@ -13,6 +13,12 @@ include $(BASE_DIR)/../tools/make/viv_sim_preamble.mak
 #-------------------------------------------------
 # Testbench Specific
 #-------------------------------------------------
+include $(LIB_DIR)/hls/Makefile.inc
+
+RFNOC_SRCS += $(abspath \
+$(HLS_IP_OUTPUT_SRCS) \
+)
+
 # Define only one toplevel module
 SIM_TOP = noc_block_addsub_tb
 

--- a/usrp3/lib/rfnoc/noc_block_addsub_tb/noc_block_addsub_tb.sv
+++ b/usrp3/lib/rfnoc/noc_block_addsub_tb/noc_block_addsub_tb.sv
@@ -18,6 +18,7 @@ module noc_block_addsub_tb();
   localparam NUM_STREAMS    = 2;  // Number of test bench streams
   `RFNOC_SIM_INIT(NUM_CE, NUM_STREAMS, BUS_CLK_PERIOD, CE_CLK_PERIOD);
   `RFNOC_ADD_BLOCK(noc_block_addsub, 0);
+  defparam noc_block_addsub.USE_HLS = 1;
 
   localparam SPP = 256; // Samples per packet
 

--- a/usrp3/tools/make/viv_hls_ip_builder.mak
+++ b/usrp3/tools/make/viv_hls_ip_builder.mak
@@ -20,6 +20,7 @@ BUILD_VIVADO_HLS_IP = \
 	export HLS_IP_NAME=$(1); \
 	export PART_NAME=$(subst /,,$(2)); \
 	export HLS_IP_SRCS='$(3)'; \
+	export HLS_IP_INCLUDES='$(6)'; \
 	echo "BUILDER: Staging HLS IP in build directory..."; \
 	$(TOOLS_DIR)/scripts/shared-ip-loc-manage.sh --path=$(5)/$(1) reserve; \
 	cp -rf $(4)/$(1)/* $(5)/$(1); \
@@ -40,6 +41,7 @@ BUILD_VIVADO_HLS_IP = \
 #       $3 = HLS_IP_SRCS (HLS IP source files relative to $4, HLS_IP_SRC_DIR)
 #       $4 = HLS_IP_SRC_DIR (Absolute path to the top level HLS IP src dir)
 #       $5 = HLS_IP_BUILD_DIR (Absolute path to the top level HLS IP build dir)
+#       $6 = HLS_INCLUDE_DIR (Optional: Absolute path to HLS include directory)
 # Prereqs:
 # - HLS_IP_OUTPUT_SRCS and HLS_IP_BUILD_TARGETS must be defined globally
 # -------------------------------------------------------------------
@@ -58,7 +60,7 @@ build_$(1) : $$(HLS_IP_$(1)_OUTS)
 
 # Build with HLS
 $$(HLS_IP_$(1)_OUTS) : $$(HLS_IP_$(1)_LIB_SRCS)
-	$$(call BUILD_VIVADO_HLS_IP,$(1),$(2),$$(HLS_IP_$(1)_LIB_SRCS),$(4),$(5))
+	$$(call BUILD_VIVADO_HLS_IP,$(1),$(2),$$(HLS_IP_$(1)_LIB_SRCS),$(4),$(5),$(6))
 
 .PHONEY : build_$(1)
 endef

--- a/usrp3/tools/make/viv_hls_ip_builder.mak
+++ b/usrp3/tools/make/viv_hls_ip_builder.mak
@@ -57,6 +57,7 @@ HLS_IP_BUILD_TARGETS += build_$(1)
 # adds them to the list of output source files
 build_$(1) : $$(HLS_IP_$(1)_OUTS)
 	$$(eval HLS_IP_OUTPUT_SRCS += $$(shell find $(5)/$(1)/solution/impl/verilog/ -name '*.v' -o -name '*.vhd' -o -name '*.xci'))
+	$$(eval HLS_IP_OUTPUT_INCS += $$(shell find $(5)/$(1)/solution/impl/verilog/ -name '*.dat'))
 
 # Build with HLS
 $$(HLS_IP_$(1)_OUTS) : $$(HLS_IP_$(1)_LIB_SRCS)

--- a/usrp3/tools/make/viv_simulator.mak
+++ b/usrp3/tools/make/viv_simulator.mak
@@ -47,7 +47,11 @@ SETUP_AND_LAUNCH_SIMULATION = \
 .SECONDEXPANSION:
 
 ##xsim:       Run the simulation using the Xilinx Vivado Simulator
-xsim: .check_tool hls_ip $(DESIGN_SRCS) $(SIM_SRCS) $(INC_SRCS)
+xsim: .check_tool $(DESIGN_SRCS) $(SIM_SRCS) $(INC_SRCS)
+	$(call SETUP_AND_LAUNCH_SIMULATION,XSim)
+
+##xsim_hls:       Run the simulation using the Xilinx Vivado Simulator. Also call hls_ip
+xsim_hls: .check_tool hls_ip $(DESIGN_SRCS) $(SIM_SRCS) $(INC_SRCS)
 	$(call SETUP_AND_LAUNCH_SIMULATION,XSim)
 
 ##xclean:     Cleanup Xilinx Vivado Simulator intermediate files
@@ -81,4 +85,4 @@ clean:: xclean vclean
 help::
 	@grep -h "##" $(abspath $(lastword $(MAKEFILE_LIST))) | grep -v "\"##\"" | sed -e 's/\\$$//' | sed -e 's/##//'
 
-.PHONY: xsim xclean vsim vlint vclean clean help
+.PHONY: xsim xsim_hls xclean vsim vlint vclean clean help

--- a/usrp3/tools/make/viv_simulator.mak
+++ b/usrp3/tools/make/viv_simulator.mak
@@ -47,7 +47,7 @@ SETUP_AND_LAUNCH_SIMULATION = \
 .SECONDEXPANSION:
 
 ##xsim:       Run the simulation using the Xilinx Vivado Simulator
-xsim: .check_tool $(DESIGN_SRCS) $(SIM_SRCS) $(INC_SRCS)
+xsim: .check_tool hls_ip $(DESIGN_SRCS) $(SIM_SRCS) $(INC_SRCS)
 	$(call SETUP_AND_LAUNCH_SIMULATION,XSim)
 
 ##xclean:     Cleanup Xilinx Vivado Simulator intermediate files

--- a/usrp3/tools/scripts/viv_generate_hls_ip.tcl
+++ b/usrp3/tools/scripts/viv_generate_hls_ip.tcl
@@ -8,6 +8,7 @@
 set part_name        $::env(PART_NAME)              ;# Full Xilinx part name
 set hls_ip_name      $::env(HLS_IP_NAME)            ;# High level synthesis IP name
 set hls_ip_srcs      $::env(HLS_IP_SRCS)            ;# High level synthesis IP source files
+set hls_ip_inc       $::env(HLS_IP_INCLUDES)        ;# High level synthesis IP include directories
 
 # ---------------------------------------
 # Vivado Commands
@@ -16,11 +17,12 @@ open_project $hls_ip_name
 open_solution "solution"
 set_part $part_name
 set_top $hls_ip_name
+puts "BUILDER: Using include location : $hls_ip_inc"
 foreach src_file $hls_ip_srcs {
     set src_ext [file extension $src_file ]
     if [expr [lsearch {.c .cpp} $src_ext] >= 0] {
         puts "BUILDER: Adding C/C++ : $src_file"
-        add_files $src_file
+        add_files $src_file -cflags "-I $hls_ip_inc"
     } elseif [expr [lsearch {.tcl} $src_ext] >= 0] {
         puts "BUILDER: Executing tcl script : $src_file"
         source $src_file


### PR DESCRIPTION
Work in progress... 

For the purpose of providing an HLS testbench example, I edited the noc_block_addsub_tb to use the HLS version of the addsub block. This required a few edits to makefiles. 

Note the testbench now seems to break for me. I have not debugged the problem yet, but it looks like the addsub AXI interface may not be working as expected. I'll take a look soon, probably this week, since I want to get a HLS noc block working...
