### PR TITLE
axi_serializer: Fixed AXI edge case

### DIFF
--- a/usrp3/lib/rfnoc/axi_serializer.v
+++ b/usrp3/lib/rfnoc/axi_serializer.v
@@ -52,7 +52,9 @@ module axi_serializer #(
         end
       end else if (~serializing) begin
         i_tready <= 1'b1;
-        o_tvalid <= 1'b0;
+        if (o_tvalid && o_tready) begin
+          o_tvalid <= 1'b0;
+        end
         // Serial shift register (serial_data_reg) is empty, load it 
         if (i_tvalid) begin
           i_tready        <= 1'b0;


### PR DESCRIPTION
This fix is needed for a nasty edge case when `o_tready` falls low at the same time `serializing` falls low...

On the next clock, we branch into the `~serializing` statement, where `o_tvalid` gets automatically pulled low, which can break AXI protocol. The fix here checks that `o_ready` is high before deasserting `o_tvalid`.

(I ran into this problem today, which dropped samples for me. This solution cleans up the dropped samples) 