### PR TITLE
Check the log for errors after running xsim

### DIFF
--- a/usrp3/tools/scripts/launch_vivado.sh
+++ b/usrp3/tools/scripts/launch_vivado.sh
@@ -88,4 +88,9 @@ do
         echo "$line"
     fi
 done
-exit ${PIPESTATUS[0]}
+
+# Vivado does not typically exit with a helpful error code, even when it fails!...
+# exit ${PIPESTATUS[0]}
+
+# Check the xsim.log for errors
+exit `grep -i ^error xsim.log -c`


### PR DESCRIPTION
It looks like the launch_vivado.sh script is designed to pass error codes from the vivado process out of the "make" call. 

Here's the interesting thing though... it seems that the "vivado" process in batch mode will consistently exit cleanly with a exit code 0, even if there's errors in the testbench. For some of my unit testing, it would be nice for this make call to exit with a non-zero exit code if vivado fails (generating IP, the testbench fails, etc etc). 

The approach here is to grep the xsim.log for any lines that start with "Error". The xsim.log is currently hardcoded into the viv_args, so we know it exists. It currently just arbitrarily returns the number of errors in the exit code. This works fine for my use case, but we can change this if it would make sense to have designated error codes.

I'm also open to other solultions. It just seems to me that the intent of the script is to throw an error if vivado has an error, but the script did not behave this way....