### PR TITLE
rfnoc: Read files in binary mode

### DIFF
--- a/usrp3/lib/rfnoc/file_source.v
+++ b/usrp3/lib/rfnoc/file_source.v
@@ -26,8 +26,8 @@ module file_source #(
 
   initial begin
     if (FILENAME != "") begin
-      file = $fopen(FILENAME, "r");
-      file_length = $fread(mem,file,0,FILE_LENGTH);
+      file = $fopen(FILENAME, "rb");
+      file_length = $fread(mem,file,0);
       $display("Read %d lines", file_length);
     end
   end


### PR DESCRIPTION
Read files in binary mode and be more flexible in file_lengths. (Perhaps remove the edit to line #30, @jpendlum ?)