### PR TITLE
rfnoc: delay is reserved in future Xilinx

### DIFF
--- a/usrp3/lib/rfnoc/delay.v
+++ b/usrp3/lib/rfnoc/delay.v
@@ -3,7 +3,7 @@
 //
 // FIXME I don't like the way this is implemented.  Should we remove the FIFO completely?
 
-module delay
+module delay_mod
   #(parameter MAX_LEN=1023,
     parameter WIDTH=16)
    (input clk, input reset, input clear,

--- a/usrp3/lib/rfnoc/schmidl_cox.v
+++ b/usrp3/lib/rfnoc/schmidl_cox.v
@@ -54,7 +54,7 @@ module schmidl_cox #(
     .o2_tdata(), .o2_tlast(), .o2_tvalid(), .o2_tready(),
     .o3_tdata(), .o3_tlast(), .o3_tvalid(), .o3_tready());
 
-  delay #(.MAX_LEN(WINDOW_LEN), .WIDTH(32)) delay_input (
+  delay_mod #(.MAX_LEN(WINDOW_LEN), .WIDTH(32)) delay_input (
     .clk(clk), .reset(reset), .clear(clear),
     .len(WINDOW_LEN),
     .i_tdata(n0_tdata), .i_tlast(n0_tlast), .i_tvalid(n0_tvalid), .i_tready(n0_tready),


### PR DESCRIPTION
This was causing a silent error while trying to use ModelSim. Suggest renaming so others don't waste time trying to debug and future-proof against upgrades of Xilinx libraries.