### PR TITLE
For usrp3 (b205) fixed compiler warnings + bug in 205.v

### DIFF
--- a/usrp3/lib/dsp/add_then_mac.v
+++ b/usrp3/lib/dsp/add_then_mac.v
@@ -37,8 +37,8 @@ module add_then_mac
    localparam  B0REG_IN = 1;
 
    // Sign extend inputs
-   assign      a_in = (a[17] == 1'b1) ? {7'hff, a} : {7'h00, a};
-   assign      d_in = (d[17] == 1'b1) ? {7'hff, d} : {7'h00, d};
+   assign      a_in = (a[17] == 1'b1) ? {7'h7f, a} : {7'h00, a};
+   assign      d_in = (d[17] == 1'b1) ? {7'h7f, d} : {7'h00, d};
 
    generate
       case(DEVICE)
@@ -110,7 +110,7 @@ module add_then_mac
 	"SPARTAN6" :
 	  begin
 	     // DSP48A1 has 18b+18b=18b pre-adder, must discard LSB of A and D and compensate by shifting ACC.
-	     wire discard;;
+	     wire discard;
 	     assign acc[0] = 1'b0;
 	     
 	     DSP48A1 #(

--- a/usrp3/lib/dsp/ddc_chain.v
+++ b/usrp3/lib/dsp/ddc_chain.v
@@ -239,9 +239,9 @@ module ddc_chain
 	 wire [17:0] i_unscaled_clip, q_unscaled_clip;
 
 	 clip_reg #(.bits_in(19), .bits_out(18), .STROBED(1)) unscaled_clip_i
-	   (.clk(clk), .in(i_unscaled[18:0]), .strobe_in(strobe_unscaled), .out(i_unscaled_clip[17:0]), .strobe_out(strobe_unscaled_clip));
+	   (.clk(clk), .reset(rst), .in(i_unscaled[18:0]), .strobe_in(strobe_unscaled), .out(i_unscaled_clip[17:0]), .strobe_out(strobe_unscaled_clip));
 	 clip_reg #(.bits_in(19), .bits_out(18), .STROBED(1)) unscaled_clip_q
-	   (.clk(clk), .in(q_unscaled[18:0]), .strobe_in(strobe_unscaled), .out(q_unscaled_clip[17:0]), .strobe_out());
+	   (.clk(clk), .reset(rst), .in(q_unscaled[18:0]), .strobe_in(strobe_unscaled), .out(q_unscaled_clip[17:0]), .strobe_out());
 
 	 // Apply scaling gain to compensate for CORDIC and CIC gain adjustments so that signal swing over network transport has
 	 // optimal dynamic range.
@@ -276,9 +276,9 @@ module ddc_chain
 	 always @(posedge clk)  strobe_scaled <= strobe_unscaled_clip;
 
 	 clip_reg #(.bits_in(36), .bits_out(33), .STROBED(1)) clip_i
-	   (.clk(clk), .in(prod_i[35:0]), .strobe_in(strobe_scaled), .out(i_clip), .strobe_out(strobe_clip));
+	   (.clk(clk), .reset(rst), .in(prod_i[35:0]), .strobe_in(strobe_scaled), .out(i_clip), .strobe_out(strobe_clip));
 	 clip_reg #(.bits_in(36), .bits_out(33), .STROBED(1)) clip_q
-	   (.clk(clk), .in(prod_q[35:0]), .strobe_in(strobe_scaled), .out(q_clip), .strobe_out());
+	   (.clk(clk), .reset(rst), .in(prod_q[35:0]), .strobe_in(strobe_scaled), .out(q_clip), .strobe_out());
 
 	 round_sd #(.WIDTH_IN(33), .WIDTH_OUT(16)) round_i
 	   (.clk(clk), .reset(rst), .in(i_clip), .strobe_in(strobe_clip), .out(sample[31:16]), .strobe_out(strobe));

--- a/usrp3/lib/dsp/ddc_chain.v
+++ b/usrp3/lib/dsp/ddc_chain.v
@@ -317,9 +317,9 @@ module ddc_chain
 	 wire [17:0] i_unscaled_clip, q_unscaled_clip;
 
 	 clip_reg #(.bits_in(19), .bits_out(18), .STROBED(1)) unscaled_clip_i
-	   (.clk(clk), .in(i_hb2[WIDTH-1:WIDTH-19]), .strobe_in(strobe_hb2), .out(i_unscaled_clip[17:0]), .strobe_out(strobe_unscaled_clip));
+	   (.clk(clk), .reset(rst), .in(i_hb2[WIDTH-1:WIDTH-19]), .strobe_in(strobe_hb2), .out(i_unscaled_clip[17:0]), .strobe_out(strobe_unscaled_clip));
 	 clip_reg #(.bits_in(19), .bits_out(18), .STROBED(1)) unscaled_clip_q
-	   (.clk(clk), .in(q_hb2[WIDTH-1:WIDTH-19]), .strobe_in(strobe_hb2), .out(q_unscaled_clip[17:0]), .strobe_out());
+	   (.clk(clk), .reset(rst), .in(q_hb2[WIDTH-1:WIDTH-19]), .strobe_in(strobe_hb2), .out(q_unscaled_clip[17:0]), .strobe_out());
 
 	 //scalar operation (gain of 6 bits)
 	 wire [35:0] 	  prod_i, prod_q;
@@ -353,9 +353,9 @@ module ddc_chain
 	 always @(posedge clk)  strobe_scaled <= strobe_unscaled_clip;
 
 	 clip_reg #(.bits_in(36), .bits_out(33), .STROBED(1)) clip_i
-	   (.clk(clk), .in(prod_i[35:0]), .strobe_in(strobe_scaled), .out(i_clip), .strobe_out(strobe_clip));
+	   (.clk(clk), .reset(rst), .in(prod_i[35:0]), .strobe_in(strobe_scaled), .out(i_clip), .strobe_out(strobe_clip));
 	 clip_reg #(.bits_in(36), .bits_out(33), .STROBED(1)) clip_q
-	   (.clk(clk), .in(prod_q[35:0]), .strobe_in(strobe_scaled), .out(q_clip), .strobe_out());
+	   (.clk(clk), .reset(rst), .in(prod_q[35:0]), .strobe_in(strobe_scaled), .out(q_clip), .strobe_out());
 
 	 round_sd #(.WIDTH_IN(33), .WIDTH_OUT(16)) round_i
 	   (.clk(clk), .reset(rst), .in(i_clip), .strobe_in(strobe_clip), .out(sample[31:16]), .strobe_out(strobe));

--- a/usrp3/lib/dsp/duc_chain.v
+++ b/usrp3/lib/dsp/duc_chain.v
@@ -225,9 +225,9 @@ module duc_chain
    // Cordic rotation coupled with a saturated input signal can cause overflow
    // so we clip here rather than allow a wrap.
    clip_reg #(.bits_in(36), .bits_out(33), .STROBED(1)) clip_i
-     (.clk(clk), .in(prod_i[35:0]), .strobe_in(1'b1), .out(i_clip), .strobe_out());
+     (.clk(clk), .reset(rst), .in(prod_i[35:0]), .strobe_in(1'b1), .out(i_clip), .strobe_out());
    clip_reg #(.bits_in(36), .bits_out(33), .STROBED(1)) clip_q
-     (.clk(clk), .in(prod_q[35:0]), .strobe_in(1'b1), .out(q_clip), .strobe_out());
+     (.clk(clk), .reset(rst), .in(prod_q[35:0]), .strobe_in(1'b1), .out(q_clip), .strobe_out());
 
    assign tx_fe_i = i_clip[32:33-WIDTH];
    assign tx_fe_q = q_clip[32:33-WIDTH];

--- a/usrp3/lib/dsp/hb47_int.v
+++ b/usrp3/lib/dsp/hb47_int.v
@@ -124,7 +124,7 @@ module hb47_int
 
    wire [34:17] 	 result_clip;
    clip_reg #(.bits_in(31),.bits_out(18)) final_clip
-     (.clk(clk),.in(result_rnd[47:17]),.strobe_in(1'b1), .out(result_clip[34:17]), .strobe_out());
+     (.clk(clk), .reset(rst), .in(result_rnd[47:17]),.strobe_in(1'b1), .out(result_clip[34:17]), .strobe_out());
 
    //
    // Data enters the sample pipeline when stb_in is asserted.

--- a/usrp3/lib/fifo/axi_mux8.v
+++ b/usrp3/lib/fifo/axi_mux8.v
@@ -48,8 +48,8 @@ module axi_mux8 #(
       .clk(clk), .reset(reset), .clear(clear),
       .i0_tdata(o_tdata_int0), .i0_tlast(o_tlast_int0), .i0_tvalid(o_tvalid_int0), .i0_tready(o_tready_int0),
       .i1_tdata(o_tdata_int1), .i1_tlast(o_tlast_int1), .i1_tvalid(o_tvalid_int1), .i1_tready(o_tready_int1),
-      .i2_tdata(0), .i2_tlast(1'b0), .i2_tvalid(1'b0), .i2_tready(),
-      .i3_tdata(0), .i3_tlast(1'b0), .i3_tvalid(1'b0), .i3_tready(),
+      .i2_tdata({WIDTH{1'b0}}), .i2_tlast(1'b0), .i2_tvalid(1'b0), .i2_tready(),
+      .i3_tdata({WIDTH{1'b0}}), .i3_tlast(1'b0), .i3_tvalid(1'b0), .i3_tready(),
       .o_tdata(o_tdata), .o_tlast(o_tlast), .o_tvalid(o_tvalid), .o_tready(o_tready)
    );
 

--- a/usrp3/lib/gpif2/gpif2_slave_fifo32.v
+++ b/usrp3/lib/gpif2/gpif2_slave_fifo32.v
@@ -71,6 +71,7 @@ module gpif2_slave_fifo32
     // GPIF input and output data lines, tristate
     //
     reg [31:0] gpif_data_in, gpif_data_out;
+    reg slrd1, slrd2, slrd3, slrd4, slrd5;
 
     always @(posedge gpif_clk)
       if (~slrd2)
@@ -111,7 +112,6 @@ module gpif2_slave_fifo32
     reg [15:0] transfer_size;
 
     // Read strobe pipeline.
-    reg slrd1, slrd2, slrd3, slrd4, slrd5;
 
    always @(posedge gpif_clk)
      if (gpif_rst) begin
@@ -403,7 +403,7 @@ module gpif2_slave_fifo32
 	     slwr <= 1'b1;
 	     sloe <= 1'b1;
 	     idle_cycles <= idle_cycles + 1'b1;
-             if (idle_cycles == 3'h001) begin
+             if (idle_cycles == 3'h1) begin
 		// FX3 should now be in internal ZLP state
 		state <= STATE_WRITE_FLUSH;
 		pktend <= 1'b0;

--- a/usrp3/lib/gpif2/gpif2_to_fifo64.v
+++ b/usrp3/lib/gpif2/gpif2_to_fifo64.v
@@ -90,7 +90,7 @@ module gpif2_to_fifo64
    wire 	    o32_tlast;
    wire 	    o32_tvalid, o32_tready;
 
-   gpif2_error_checker #(.SIZE(FIFO_SIZE)) checker
+   gpif2_error_checker #(.SIZE(FIFO_SIZE)) error_checker
      (
       .clk(fifo_clk), .reset(fifo_rst), .clear(1'b0),
       .i_tdata(chk_tdata), .i_tlast(chk_tlast), .i_tvalid(chk_tvalid), .i_tready(chk_tready),

--- a/usrp3/lib/radio_200/radio_legacy.v
+++ b/usrp3/lib/radio_200/radio_legacy.v
@@ -161,7 +161,7 @@ module radio_legacy
       .ready(1'b1), .readback(rb_data),
       .debug(debug_radio_ctrl_proc));
 
-   reg [63:0]     rb_data_user;
+   wire [63:0]     rb_data_user;
 generate
    if (USER_SETTINGS == 1) begin
       wire           set_stb_user;
@@ -195,16 +195,12 @@ generate
         (.clk(radio_clk), .rst(radio_rst), .strobe(set_stb_user), .addr(set_addr_user), .in(set_data_user),
          .out(user_reg_1_value), .changed());
 
-      always @* begin
-         case(rb_addr_user)
-            8'd0 : rb_data_user <= {user_reg_1_value, user_reg_0_value};
-            default : rb_data_user <= 64'd0;
-         endcase
-      end
+      assign rb_data_user = (rb_addr_user == 8'd0) ?
+                            {user_reg_1_value, user_reg_0_value} : 64'd0;
       */
 
    end else begin    //for USER_SETTINGS == 1
-      always rb_data_user <= 64'd0;
+      assign rb_data_user = 64'd0;
    end
 endgenerate
 

--- a/usrp3/lib/radio_200/radio_legacy.v
+++ b/usrp3/lib/radio_200/radio_legacy.v
@@ -204,7 +204,7 @@ generate
       */
 
    end else begin    //for USER_SETTINGS == 1
-      always @* rb_data_user <= 64'd0;
+      always rb_data_user <= 64'd0;
    end
 endgenerate
 

--- a/usrp3/lib/vita_200/chdr_12sc_to_16sc.v
+++ b/usrp3/lib/vita_200/chdr_12sc_to_16sc.v
@@ -55,7 +55,7 @@ module chdr_12sc_to_16sc
 
    setting_reg #(.my_addr(BASE), .width(17)) new_destination
      (.clk(clk), .rst(reset), .strobe(set_stb), .addr(set_addr), .in(set_data),
-      .out({set_sid, my_newhome[15:0]}));
+      .out({set_sid, my_newhome[15:0]}), .changed());
 
    localparam HEADER = 3'd0; // IDLE
    localparam TIME     = 3'd1;

--- a/usrp3/lib/vita_200/chdr_16sc_to_12sc.v
+++ b/usrp3/lib/vita_200/chdr_16sc_to_12sc.v
@@ -66,7 +66,7 @@ module chdr_16sc_to_12sc
 
    setting_reg #(.my_addr(BASE), .width(17)) new_destination
      (.clk(clk), .rst(reset), .strobe(set_stb), .addr(set_addr), .in(set_data),
-      .out({set_sid, new_sid_dst[15:0]}));
+      .out({set_sid, new_sid_dst[15:0]}), .changed());
    // state machine
 
    localparam 		HEADER  = 3'd0;

--- a/usrp3/lib/vita_200/chdr_16sc_to_32f.v
+++ b/usrp3/lib/vita_200/chdr_16sc_to_32f.v
@@ -51,7 +51,7 @@ module chdr_16sc_to_32f
    wire [15:0] 	      my_newhome;
 
    setting_reg #(.my_addr(BASE), .width(17)) new_destination
-     (.clk(clk), .rst(reset), .strobe(set_stb), .addr(set_addr), .in(set_data),.out({set_sid, my_newhome[15:0]}));
+     (.clk(clk), .rst(reset), .strobe(set_stb), .addr(set_addr), .in(set_data),.out({set_sid, my_newhome[15:0]}), .changed());
 
  
 

--- a/usrp3/lib/vita_200/chdr_16sc_to_8sc.v
+++ b/usrp3/lib/vita_200/chdr_16sc_to_8sc.v
@@ -49,7 +49,7 @@ module chdr_16sc_to_8sc
    
    setting_reg #(.my_addr(BASE), .width(17)) new_destination
      (.clk(clk), .rst(reset), .strobe(set_stb), .addr(set_addr), .in(set_data),
-      .out({set_sid, my_newhome[15:0]}));
+      .out({set_sid, my_newhome[15:0]}), .changed());
 
    localparam HEADER        = 2'd0;//IDLE
    localparam TIME          = 2'd1;
@@ -109,55 +109,62 @@ module chdr_16sc_to_8sc
 	   .bits_out(8))
    round_i2
      (.in(i_tdata[63:48]), 
-      .out(rounded_i2[7:0])
+      .out(rounded_i2[7:0]),
+      .err()
 	    );
 
    round #(.bits_in(16),
            .bits_out(8))
    round_q2
      (.in(i_tdata[47:32]),
-      .out(rounded_q2[7:0])
+      .out(rounded_q2[7:0]),
+      .err()
       );
 
    round #(.bits_in(16),
            .bits_out(8))
    round_i3
      (.in(i_tdata[31:16]),
-      .out(rounded_i3[7:0])
+      .out(rounded_i3[7:0]),
+      .err()
       );
 
    round #(.bits_in(16),
            .bits_out(8))
    round_q3
      (.in(i_tdata[15:0]),
-      .out(rounded_q3[7:0])
+      .out(rounded_q3[7:0]),
+      .err()
       );
 
    // old data processing 
    round #(.bits_in(16),
 	   .bits_out(8))
-   round_i0(.in(hold_tdata[63:48]), .out(rounded_i0[7:0])
+   round_i0(.in(hold_tdata[63:48]), .out(rounded_i0[7:0]), .err()
 	    );
 
    round #(.bits_in(16),
            .bits_out(8))
    round_q0
      (.in(hold_tdata[47:32]),
-      .out(rounded_q0[7:0])
+      .out(rounded_q0[7:0]),
+      .err()
       );
 
    round #(.bits_in(16),
            .bits_out(8))
    round_i1
      (.in(hold_tdata[31:16]),
-      .out(rounded_i1[7:0])
+      .out(rounded_i1[7:0]),
+      .err()
       );
 
    round #(.bits_in(16),
            .bits_out(8))
    round_q1
      (.in(hold_tdata[15:0]),
-      .out(rounded_q1[7:0])
+      .out(rounded_q1[7:0]),
+      .err()
       );
    
    // main mux

--- a/usrp3/lib/vita_200/chdr_16sc_to_xxxx_chain.v
+++ b/usrp3/lib/vita_200/chdr_16sc_to_xxxx_chain.v
@@ -59,23 +59,26 @@ module chdr_16sc_to_xxxx_chain
    chdr_16sc_to_12sc
      #(.BASE(89)) convert_16sc_to_12sc
       
-       (.clk(clk), .reset(reset),.set_data(0), .set_stb(0), .set_addr(0),
+       (.clk(clk), .reset(reset),.set_data(32'h0), .set_stb(1'h0), .set_addr(8'h0),
        .i_tdata(i1_tdata), .i_tlast(i1_tlast), .i_tvalid(i1_tvalid), .i_tready(i1_tready),
-       .o_tdata(o1_tdata), .o_tlast(o1_tlast), .o_tvalid(o1_tvalid), .o_tready(o1_tready)
+       .o_tdata(o1_tdata), .o_tlast(o1_tlast), .o_tvalid(o1_tvalid), .o_tready(o1_tready),
+       .debug()
        );
 
    chdr_16sc_to_32f
      #(.BASE(89)) convert_16sc_to_32f
       
-       (.clk(clk), .reset(reset),.set_data(0), .set_stb(0), .set_addr(0),
+       (.clk(clk), .reset(reset),.set_data(32'h0), .set_stb(1'h0), .set_addr(8'h0),
        .i_tdata(i2_tdata), .i_tlast(i2_tlast), .i_tvalid(i2_tvalid), .i_tready(i2_tready),
-       .o_tdata(o2_tdata), .o_tlast(o2_tlast), .o_tvalid(o2_tvalid), .o_tready(o2_tready)
+       .o_tdata(o2_tdata), .o_tlast(o2_tlast), .o_tvalid(o2_tvalid), .o_tready(o2_tready),
+       .debug()
        );
 
    chdr_16sc_to_8sc #(.BASE(89)) convert_16sc_to_8sc
-     (.clk(clk), .reset(reset),.set_data(0), .set_stb(0), .set_addr(0),
+     (.clk(clk), .reset(reset),.set_data(32'h0), .set_stb(1'h0), .set_addr(8'h0),
       .i_tdata(i3_tdata), .i_tlast(i3_tlast), .i_tvalid(i3_tvalid), .i_tready(i3_tready),
-      .o_tdata(o3_tdata), .o_tlast(o3_tlast), .o_tvalid(o3_tvalid), .o_tready(o3_tready)
+      .o_tdata(o3_tdata), .o_tlast(o3_tlast), .o_tvalid(o3_tvalid), .o_tready(o3_tready),
+      .debug()
       );
    
 

--- a/usrp3/lib/vita_200/chdr_32f_to_16sc.v
+++ b/usrp3/lib/vita_200/chdr_32f_to_16sc.v
@@ -57,7 +57,7 @@ module chdr_32f_to_16sc
 
    setting_reg #(.my_addr(BASE), .width(17)) new_destination
      (.clk(clk), .rst(reset), .strobe(set_stb), .addr(set_addr), .in(set_data),
-      .out({set_sid, my_newhome[15:0]}));
+      .out({set_sid, my_newhome[15:0]}), .changed());
 
  
 

--- a/usrp3/lib/vita_200/chdr_8sc_to_16sc.v
+++ b/usrp3/lib/vita_200/chdr_8sc_to_16sc.v
@@ -39,7 +39,7 @@ module chdr_8sc_to_16sc
 
    setting_reg #(.my_addr(BASE), .width(17)) new_destination
      (.clk(clk), .rst(reset), .strobe(set_stb), .addr(set_addr), .in(set_data),
-      .out({set_sid, my_newhome[15:0]}));
+      .out({set_sid, my_newhome[15:0]}), .changed());
 
 
    //state declarations

--- a/usrp3/lib/vita_200/chdr_xxxx_to_16sc_chain.v
+++ b/usrp3/lib/vita_200/chdr_xxxx_to_16sc_chain.v
@@ -60,24 +60,27 @@ module chdr_xxxx_to_16sc_chain
     chdr_12sc_to_16sc
     #(.BASE(89)) convert_12sc_to_16sc
     
-    (.clk(clk), .reset(reset),.set_data(0), .set_stb(0), .set_addr(0),
+    (.clk(clk), .reset(reset),.set_data(32'h0), .set_stb(1'h0), .set_addr(8'h0),
     .i_tdata(i1_tdata), .i_tlast(i1_tlast), .i_tvalid(i1_tvalid), .i_tready(i1_tready),
-    .o_tdata(o1_tdata), .o_tlast(o1_tlast), .o_tvalid(o1_tvalid), .o_tready(o1_tready)
+    .o_tdata(o1_tdata), .o_tlast(o1_tlast), .o_tvalid(o1_tvalid), .o_tready(o1_tready),
+    .debug()
     );
 
     chdr_32f_to_16sc
     #(.BASE(89)) convert_32f_to_16sc
     
-    (.clk(clk), .reset(reset),.set_data(0), .set_stb(0), .set_addr(0),
+    (.clk(clk), .reset(reset),.set_data(32'h0), .set_stb(1'h0), .set_addr(8'h0),
     .i_tdata(i2_tdata), .i_tlast(i2_tlast), .i_tvalid(i2_tvalid), .i_tready(i2_tready),
-    .o_tdata(o2_tdata), .o_tlast(o2_tlast), .o_tvalid(o2_tvalid), .o_tready(o2_tready)
+    .o_tdata(o2_tdata), .o_tlast(o2_tlast), .o_tvalid(o2_tvalid), .o_tready(o2_tready),
+    .debug()
     );
 
     
    chdr_8sc_to_16sc #(.BASE(89)) convert_8sc_to_16sc
-     (.clk(clk), .reset(reset),.set_data(0), .set_stb(0), .set_addr(0),
+     (.clk(clk), .reset(reset),.set_data(32'h0), .set_stb(1'h0), .set_addr(8'h0),
       .i_tdata(i3_tdata), .i_tlast(i3_tlast), .i_tvalid(i3_tvalid), .i_tready(i3_tready),
-      .o_tdata(o3_tdata), .o_tlast(o3_tlast), .o_tvalid(o3_tvalid), .o_tready(o3_tready)
+      .o_tdata(o3_tdata), .o_tlast(o3_tlast), .o_tvalid(o3_tvalid), .o_tready(o3_tready),
+      .debug()
       );
    
 

--- a/usrp3/lib/vita_200/float_to_iq.v
+++ b/usrp3/lib/vita_200/float_to_iq.v
@@ -61,7 +61,7 @@ module float_to_iq
    
    
 
-   assign out = (pos_inf)?{1'b0,15'h7FFF}:(neg_inf)?{1'b1,15'h8000}:(denorm || tiny_exp)? 16'b0: final_val;
+   assign out = (pos_inf)?{1'b0,15'h7FFF}:(neg_inf)?{1'b1,15'h0}:(denorm || tiny_exp)? 16'b0: final_val;
    
 
 

--- a/usrp3/lib/vita_200/new_rx_framer.v
+++ b/usrp3/lib/vita_200/new_rx_framer.v
@@ -43,6 +43,8 @@ module new_rx_framer
    wire [15:0] 	  maxlen;
    reg [31:0] 	  holding;
 
+   wire 	  hdr_tready;
+
 
    // FIXME need to handle case where hdr fifo is full (i.e. too many tiny packets)
    assign full = (sample_space == 16'd0) | (sample_space == 16'd1) | ~hdr_tready;
@@ -63,6 +65,9 @@ module new_rx_framer
    reg [1:0] 	  instate;
    reg [15:0] 	  numsamps;
    reg 		  nearly_eop;
+
+   wire 	  eop = eob | nearly_eop | full;
+   wire 	  sample_tlast = eop;
 
 
    always @(posedge clk)
@@ -161,16 +166,13 @@ module new_rx_framer
 
 
 
-   wire 	  eop = eob | nearly_eop | full;
 
    wire [63:0] 	  sample_tdata = (instate == SECOND) ? {holding, sample} : {sample, 32'h0};
-   wire 	  sample_tlast = eop;
    wire 	  sample_tvalid = run & strobe & ( (instate == SECOND) | eop );
    wire 	  sample_tready;
 
    wire [80:0] 	  hdr_tdata = {eob,len[13:0],2'b0,(instate == START) ? vita_time : hold_time};
    wire 	  hdr_tvalid = sample_tlast && sample_tvalid && sample_tready;
-   wire 	  hdr_tready;
 
    wire [80:0] 	  hfifo_tdata_tmp;
    wire 	  hfifo_tvalid_tmp, hfifo_tready_tmp;

--- a/usrp3/lib/vita_200/new_tx_control.v
+++ b/usrp3/lib/vita_200/new_tx_control.v
@@ -51,9 +51,6 @@ module new_tx_control
      time_compare (.clk(clk), .reset(reset), .time_now(vita_time), .trigger_time(send_time),
                    .now(now), .early(early), .late(late), .too_early(too_early));
 
-   assign run = (state == ST_SAMP0) | (state == ST_SAMP1);
-   assign sample = (state == ST_SAMP0) ? sample0 : sample1;
-
    reg [2:0] state;
 
    localparam ST_IDLE  = 0;
@@ -61,6 +58,9 @@ module new_tx_control
    localparam ST_SAMP1 = 2;
    localparam ST_ERROR = 3;
    localparam ST_WAIT  = 4;
+
+   assign run = (state == ST_SAMP0) | (state == ST_SAMP1);
+   assign sample = (state == ST_SAMP0) ? sample0 : sample1;
 
    reg [11:0] expected_seqnum;
 

--- a/usrp3/lib/wishbone/simple_uart.v
+++ b/usrp3/lib/wishbone/simple_uart.v
@@ -50,7 +50,7 @@ module simple_uart
    simple_uart_tx simple_uart_tx
      (.clk(clk_i),.rst(rst_i),
       .fifo_in(dat_i[7:0]),.fifo_write(ack_o && wb_wr && (adr_i == SUART_TXCHAR)),
-      .fifo_level(tx_fifo_level),.fifo_full(tx_fifo_full),
+      .fifo_level(tx_fifo_level[5:0]),.fifo_full(tx_fifo_full),
       .clkdiv(clkdiv),.baudclk(baud_o),.tx(tx_o));
 
    simple_uart_rx simple_uart_rx

--- a/usrp3/lib/wishbone/simple_uart_tx.v
+++ b/usrp3/lib/wishbone/simple_uart_tx.v
@@ -16,9 +16,11 @@ module simple_uart_tx
    wire 	  read, empty;
    wire [7:0] 	  char_to_send;
    wire 	  i_tready, o_tvalid;
+   wire [15:0]    fifo_space;
 
    assign fifo_full = ~i_tready;
    assign empty = ~o_tvalid;
+   assign fifo_level = fifo_space[5:0];
 
    axi_fifo #(.WIDTH(8), .SIZE(SIZE)) fifo
      (.clk(clk),.reset(rst), .clear(1'b0),

--- a/usrp3/lib/wishbone/simple_uart_tx.v
+++ b/usrp3/lib/wishbone/simple_uart_tx.v
@@ -26,7 +26,7 @@ module simple_uart_tx
      (.clk(clk),.reset(rst), .clear(1'b0),
       .i_tdata(fifo_in), .i_tvalid(fifo_write), .i_tready(i_tready),
       .o_tdata(char_to_send),.o_tvalid(o_tvalid),.o_tready(read),
-      .space(fifo_level),.occupied() );
+      .space(fifo_space),.occupied() );
 
    always @(posedge clk)
      if(rst)

--- a/usrp3/top/b200/b200_io.v
+++ b/usrp3/top/b200/b200_io.v
@@ -41,6 +41,7 @@ module b200_io
    //
    //------------------------------------------------------------------
    reg 		   mimo_sync, mimo_sync2;
+   wire            siso_clk;
 
    always @(posedge siso_clk) begin
       mimo_sync <= mimo_sync2;
@@ -391,6 +392,7 @@ module b200_io
    // even if it works in the real world depending on how well the STA tool can do automatic case analysis.
    //
    //------------------------------------------------------------------
+   wire tx_strobe;
    // This code lock only relevent in MIMO mode.
    always @(negedge siso_clk)
      if (tx_strobe)
@@ -455,7 +457,6 @@ module b200_io
    // Mux I & Q, Ch A & B onto fullrate clockTX bus to AD9361
    //
    //------------------------------------------------------------------
-   wire tx_strobe;
    reg [11:0] tx_i_del, tx_q_del;
 
    reg 	      find_radio_clk_phase = 1'b0;

--- a/usrp3/top/b2xxmini/b205.v
+++ b/usrp3/top/b2xxmini/b205.v
@@ -167,7 +167,7 @@ module b205 (
 
    b205_io b205_io_i0
      (
-      .reset(reset),
+      .reset(reset_global),
       // Baseband sample interface
       .radio_clk(radio_clk),
       .rx_i0(rx_data[31:20]),

--- a/usrp3/top/b2xxmini/b205.v
+++ b/usrp3/top/b2xxmini/b205.v
@@ -151,7 +151,7 @@ module b205 (
         .reset(ref_pll_rst),
         .clk(ref_pll_clk),
         .refclk(int_40mhz),
-        .ref(ext_ref),
+        .extref(ext_ref),
         .locked(ext_ref_locked),
         .sclk(CLK_40M_DAC_SCLK),
         .mosi(CLK_40M_DAC_DIN),

--- a/usrp3/top/b2xxmini/b205_core.v
+++ b/usrp3/top/b2xxmini/b205_core.v
@@ -87,7 +87,7 @@ module b205_core
     // Generate an internal PPS signal
     wire int_pps;
     pps_generator #(.CLK_FREQ(100000000)) pps_gen
-    (.clk(bus_clk), .pps(int_pps));
+    (.clk(bus_clk), .reset(1'b0), .pps(int_pps));
 
     // Flop PPS signals into radio clock domain
     reg [1:0] 	 ext_pps_del, int_pps_del;
@@ -199,7 +199,7 @@ module b205_core
     (
         .clock(bus_clk), .reset(bus_rst),
         .set_stb(set_stb), .set_addr(set_addr), .set_data(set_data),
-        .readback(spi_readback), .ready(spi_ready),
+        .readback(spi_readback), .readback_stb(), .ready(spi_ready),
         .sen(sen), .sclk(sclk), .mosi(mosi), .miso(miso),
         .debug()
     );
@@ -241,7 +241,7 @@ module b205_core
         .rx_tdata(rx_tdata), .rx_tlast(rx_tlast),  .rx_tvalid(rx_tvalid), .rx_tready(rx_tready),
         .ctrl_tdata(r0_ctrl_tdata), .ctrl_tlast(r0_ctrl_tlast),  .ctrl_tvalid(r0_ctrl_tvalid), .ctrl_tready(r0_ctrl_tready),
         .resp_tdata(r0_resp_tdata), .resp_tlast(r0_resp_tlast),  .resp_tvalid(r0_resp_tvalid), .resp_tready(r0_resp_tready),
-        .debug()
+        .vita_time_b(), .debug()
     );
 
 

--- a/usrp3/top/b2xxmini/b205_ref_pll.v
+++ b/usrp3/top/b2xxmini/b205_ref_pll.v
@@ -6,7 +6,7 @@ module b205_ref_pll(
     input reset,
     input clk,      // 200 MHz sample clock
     input refclk,   // 40 MHz reference clock
-    input ref,      // PPS or 10 MHz external reference
+    input extref,   // PPS or 10 MHz external reference
     output reg locked,
 
     // SPI lines to AD5662
@@ -17,8 +17,8 @@ module b205_ref_pll(
 
     // Base parameters
     localparam SAMPLE_CLOCK_FREQ=200_000_000;
-    localparam REF_FREQ_PPS=1;
-    localparam REF_FREQ_10MHZ=10_000_000;
+    localparam EXT_REF_FREQ_PPS=1;
+    localparam EXT_REF_FREQ_10MHZ=10_000_000;
     localparam REF_CLK_FREQ=40_000_000;
     localparam PFD_FREQ_PPS=1;
     localparam PFD_FREQ_10MHZ=10;
@@ -30,16 +30,16 @@ module b205_ref_pll(
 
     // Reference frequency detection parameters
     // References are only valid if they are +/-5ppm because that is the range of the VCTXCO
-    localparam REF_PERIOD_PPS=SAMPLE_CLOCK_FREQ/REF_FREQ_PPS;
-    localparam REF_PERIOD_10MHZ=SAMPLE_CLOCK_FREQ/REF_FREQ_10MHZ;
-    localparam REF_PERIOD_PPS_MIN=REF_PERIOD_PPS-(REF_PERIOD_PPS*5/1_000_000)-1;
-    localparam REF_PERIOD_PPS_MAX=REF_PERIOD_PPS+(REF_PERIOD_PPS*5/1_000_000)+1;
-    localparam REF_PERIOD_10MHZ_MIN=REF_PERIOD_10MHZ-(REF_PERIOD_10MHZ*5/1_000_000)-1;
-    localparam REF_PERIOD_10MHZ_MAX=REF_PERIOD_10MHZ+(REF_PERIOD_10MHZ*5/1_000_000)+1;
+    localparam EXT_REF_PERIOD_PPS=SAMPLE_CLOCK_FREQ/EXT_REF_FREQ_PPS;
+    localparam EXT_REF_PERIOD_10MHZ=SAMPLE_CLOCK_FREQ/EXT_REF_FREQ_10MHZ;
+    localparam EXT_REF_PERIOD_PPS_MIN=EXT_REF_PERIOD_PPS-(EXT_REF_PERIOD_PPS*5/1_000_000)-1;
+    localparam EXT_REF_PERIOD_PPS_MAX=EXT_REF_PERIOD_PPS+(EXT_REF_PERIOD_PPS*5/1_000_000)+1;
+    localparam EXT_REF_PERIOD_10MHZ_MIN=EXT_REF_PERIOD_10MHZ-(EXT_REF_PERIOD_10MHZ*5/1_000_000)-1;
+    localparam EXT_REF_PERIOD_10MHZ_MAX=EXT_REF_PERIOD_10MHZ+(EXT_REF_PERIOD_10MHZ*5/1_000_000)+1;
 
     // R divider parameters
-    localparam RDIV_PPS=REF_FREQ_PPS/PFD_FREQ_PPS;
-    localparam RDIV_10MHZ=REF_FREQ_10MHZ/PFD_FREQ_10MHZ;
+    localparam RDIV_PPS=EXT_REF_FREQ_PPS/PFD_FREQ_PPS;
+    localparam RDIV_10MHZ=EXT_REF_FREQ_10MHZ/PFD_FREQ_10MHZ;
 
     // N divider parameters (refclk is divided by 2)
     localparam NDIV_PPS=REF_CLK_FREQ/2/PFD_FREQ_PPS;
@@ -58,65 +58,65 @@ module b205_ref_pll(
     end
 
     // flop signals into sample clock domain together
-    reg [3:0] refsmp;
+    reg [3:0] extrefsmp;
     reg [3:0] refclksmp;
     always @(posedge clk) begin
-        refsmp <= {refsmp[2:0],ref};
+        extrefsmp <= {extrefsmp[2:0],extref};
         refclksmp <= {refclksmp[2:0],refclk_div};
     end
 
     // rising edge detection
-    wire ref_rising = (refsmp[3:2] == 2'b01);
+    wire extref_rising = (extrefsmp[3:2] == 2'b01);
     wire refclk_rising = (refclksmp[3:2] == 2'b01);
 
     // reference frequency detection
-    reg [27:0] refcnt;
-    reg ref_detected;
-    reg ref_is_10M;
-    reg ref_is_pps;
-    wire valid_ref = ref_is_10M | ref_is_pps;
+    reg [27:0] extrefcnt;
+    reg extref_detected;
+    reg extref_is_10M;
+    reg extref_is_pps;
+    wire valid_extref = extref_is_10M | extref_is_pps;
     always @(posedge clk) begin
         if (reset) begin
-            refcnt <= 28'd0;
-            ref_detected <= 1'b0;
-            ref_is_10M <= 1'b0;
-            ref_is_pps <= 1'b0;
+            extrefcnt <= 28'd0;
+            extref_detected <= 1'b0;
+            extref_is_10M <= 1'b0;
+            extref_is_pps <= 1'b0;
         end
-        else if (ref_rising) begin
-            refcnt <= 28'd1;
-            ref_detected <= 1'b1;
-            ref_is_10M <= ((refcnt >= REF_PERIOD_10MHZ_MIN) && (refcnt <= REF_PERIOD_10MHZ_MAX));
-            ref_is_pps <= ((refcnt >= REF_PERIOD_PPS_MIN) && (refcnt <= REF_PERIOD_PPS_MAX));
+        else if (extref_rising) begin
+            extrefcnt <= 28'd1;
+            extref_detected <= 1'b1;
+            extref_is_10M <= ((extrefcnt >= EXT_REF_PERIOD_10MHZ_MIN) && (extrefcnt <= EXT_REF_PERIOD_10MHZ_MAX));
+            extref_is_pps <= ((extrefcnt >= EXT_REF_PERIOD_PPS_MIN) && (extrefcnt <= EXT_REF_PERIOD_PPS_MAX));
         end
-        else if ((ref_is_10M && (refcnt > REF_PERIOD_10MHZ_MAX)) || (refcnt > REF_PERIOD_PPS_MAX)) begin
+        else if ((extref_is_10M && (extrefcnt > EXT_REF_PERIOD_10MHZ_MAX)) || (extrefcnt > EXT_REF_PERIOD_PPS_MAX)) begin
             // consider the reference lost
-            refcnt <= 28'd0;
-            ref_detected <= 1'b0;
-            ref_is_10M <= 1'b0;
-            ref_is_pps <= 1'b0;
+            extrefcnt <= 28'd0;
+            extref_detected <= 1'b0;
+            extref_is_10M <= 1'b0;
+            extref_is_pps <= 1'b0;
         end
-        else if (ref_detected)
-            refcnt <= refcnt + 28'd1;
+        else if (extref_detected)
+            extrefcnt <= extrefcnt + 28'd1;
     end
 
     // R divider
-    wire [23:0] rdiv = ref_is_10M ? RDIV_10MHZ : RDIV_PPS;
+    wire [23:0] rdiv = extref_is_10M ? RDIV_10MHZ : RDIV_PPS;
     reg [23:0] rcnt;
-    wire [23:0] next_rcnt = ~valid_ref ? 24'd0 : (rcnt == rdiv) ? 24'd1 : rcnt + 1'b1;
+    wire [23:0] next_rcnt = ~valid_extref ? 24'd0 : (rcnt == rdiv) ? 24'd1 : rcnt + 1'b1;
     reg r_rising;
     always @(posedge clk) begin
-        if (ref_rising)
+        if (extref_rising)
             rcnt <= next_rcnt;
-        r_rising <= (ref_rising && ((ref_is_10M && (rcnt == rdiv)) || ref_is_pps));
+        r_rising <= (extref_rising && ((extref_is_10M && (rcnt == rdiv)) || extref_is_pps));
     end
 
     // N divider
-    // Enable on rising edge of R after valid_ref
+    // Enable on rising edge of R after valid_extref
     // is asserted so R and N signals start aligned.
     // Disable if reference lost.
-    wire [25:0] ndiv = ref_is_10M ? NDIV_10MHZ : NDIV_PPS;
+    wire [25:0] ndiv = extref_is_10M ? NDIV_10MHZ : NDIV_PPS;
     reg [25:0] ncnt;
-    wire [25:0] next_ncnt = ~valid_ref ? 26'd0 : ncnt == ndiv ? 26'd1 : ncnt + 1'b1;
+    wire [25:0] next_ncnt = ~valid_extref ? 26'd0 : ncnt == ndiv ? 26'd1 : ncnt + 1'b1;
     reg n_rising;
     always @(posedge clk) begin
 		if (refclk_rising)
@@ -125,11 +125,11 @@ module b205_ref_pll(
     end
 
     // Frequency Counter
-    wire signed [28:0] period = ref_is_10M ? PFD_PERIOD_10MHZ : PFD_PERIOD_PPS;
+    wire signed [28:0] period = extref_is_10M ? PFD_PERIOD_10MHZ : PFD_PERIOD_PPS;
     reg signed [28:0] r_period_cnt;
     reg signed [28:0] freq_err;
     always @(posedge clk) begin
-        if (reset | ~valid_ref) begin
+        if (reset | ~valid_extref) begin
             r_period_cnt <= 28'd0;
             freq_err <= 29'sd0;
         end
@@ -149,7 +149,7 @@ module b205_ref_pll(
         // Count how much N leads R
         // The count is negative because it measures
         // how much the VCTCXO must be slowed down.
-        if (~valid_ref | n_rising) begin
+        if (~valid_extref | n_rising) begin
             lead_cnt <= 29'sd0;
             lead_cnt_ena <= 1'b1;
             if (r_rising)
@@ -183,7 +183,7 @@ module b205_ref_pll(
     localparam APPLY_OUTPUT_VALUE=4'd8;
     reg [3:0] state;
     reg [15:0] daco = 16'd32767;
-    wire signed [28:0] lock_margin = ref_is_10M ? LOCK_MARGIN_10MHZ : LOCK_MARGIN_PPS;
+    wire signed [28:0] lock_margin = extref_is_10M ? LOCK_MARGIN_10MHZ : LOCK_MARGIN_PPS;
     wire signed [28:0] lag = lead + period;
     reg signed [28:0] phase_err;
     reg signed [28:0] err;
@@ -193,7 +193,7 @@ module b205_ref_pll(
     reg signed [28:0] sum;
     reg [2:0] ld;
     always @(posedge clk) begin
-        if (reset || ~valid_ref) begin
+        if (reset || ~valid_extref) begin
             state <= MEASURE;
             daco <= 16'd32767;
             err <= 29'sd0;
@@ -225,7 +225,7 @@ module b205_ref_pll(
                 end
                 CALCULATE_ERROR: begin
                     err <= phase_err + freq_err;
-                    state <= ref_is_10M ? CALCULATE_10M_GAIN : CALCULATE_ADJUSTMENT;
+                    state <= extref_is_10M ? CALCULATE_10M_GAIN : CALCULATE_ADJUSTMENT;
                 end
                 CALCULATE_10M_GAIN: begin
                     shift <= (err < -7 || err > 7) ? 7 : (err < 0 ? -err : err);
@@ -238,7 +238,7 @@ module b205_ref_pll(
                     // which works out to 21.845 DAC units to correct each unit of error.
                     // Theory is nice, but the proportional and integral gains used here
                     // were determined through manual tuning.
-                    if (ref_is_10M)
+                    if (extref_is_10M)
                         adj <= (err <<< shift);
                     else
                         adj <= (err <<< 4) - err;


### PR DESCRIPTION
For usrp3 (b205) fixed compiler warnings. The bug that in 205.v instead of "global_reset" the signal was called "reset" was corrected.