### PR TITLE
e310: Reduce default rfnoc CEs by one axi_fifo_loopback

### DIFF
--- a/usrp3/top/e300/rfnoc_ce_auto_inst_e310.v
+++ b/usrp3/top/e300/rfnoc_ce_auto_inst_e310.v
@@ -1,4 +1,4 @@
-  localparam NUM_CE = 6;  // Must be no more than 14 (2 ports taken by radio core & PS-PL DMA).
+  localparam NUM_CE = 5;  // Must be no more than 14 (2 ports taken by radio core & PS-PL DMA).
 
   wire [NUM_CE*64-1:0] ce_flat_o_tdata, ce_flat_i_tdata;
   wire [63:0]          ce_o_tdata[0:NUM_CE-1], ce_i_tdata[0:NUM_CE-1];
@@ -46,16 +46,9 @@
     .o_tdata(ce_i_tdata[3]), .o_tlast(ce_i_tlast[3]), .o_tvalid(ce_i_tvalid[3]), .o_tready(ce_i_tready[3]),
     .debug(ce_debug[3]));
 
-  noc_block_axi_fifo_loopback inst_axi_fifo_loopback2 (
+  noc_block_fir_filter inst_noc_block_fir_filter (
     .bus_clk(bus_clk), .bus_rst(bus_rst),
     .ce_clk(ce_clk), .ce_rst(ce_rst),
     .i_tdata(ce_o_tdata[4]), .i_tlast(ce_o_tlast[4]), .i_tvalid(ce_o_tvalid[4]), .i_tready(ce_o_tready[4]),
     .o_tdata(ce_i_tdata[4]), .o_tlast(ce_i_tlast[4]), .o_tvalid(ce_i_tvalid[4]), .o_tready(ce_i_tready[4]),
     .debug(ce_debug[4]));
-
-  noc_block_fir_filter inst_noc_block_fir_filter (
-    .bus_clk(bus_clk), .bus_rst(bus_rst),
-    .ce_clk(ce_clk), .ce_rst(ce_rst),
-    .i_tdata(ce_o_tdata[5]), .i_tlast(ce_o_tlast[5]), .i_tvalid(ce_o_tvalid[5]), .i_tready(ce_o_tready[5]),
-    .o_tdata(ce_i_tdata[5]), .o_tlast(ce_i_tlast[5]), .o_tvalid(ce_i_tvalid[5]), .o_tready(ce_i_tready[5]),
-    .debug(ce_debug[5]));


### PR DESCRIPTION
Resource requirements for the E310 now appears a little bit too large for the specified rfnoc_ce_auto_inst_e310.v

Remove one of the FIFOs 