### PR TITLE
axi_round_and_clip: Fix incorrect comparison in generate function

### DIFF
--- a/usrp3/lib/rfnoc/axi_round_and_clip.v
+++ b/usrp3/lib/rfnoc/axi_round_and_clip.v
@@ -21,7 +21,7 @@ module axi_round_and_clip
   wire int_tlast, int_tvalid, int_tready;
 
   generate
-    if (CLIP_BITS == WIDTH_OUT) begin
+    if (WIDTH_IN == WIDTH_OUT+CLIP_BITS) begin
        assign int_tdata    = i_tdata;
        assign int_tlast    = i_tlast;
        assign int_tvalid   = i_tvalid;


### PR DESCRIPTION
Fix incorrect comparison in generate function that removed axi_round

Old version would remove the axi_round data path if WIDTH_OUT == CLIP_BITS,
which incorrectly fails when WIDTH_OUT actually equals CLIP_BITS...

For example if I want to extract the middle 8-bits of a 24 bit number, I would use:
WIDTH_IN=24
WIDTH_OUT=8
CLIP_BITS=8