### PR TITLE
Updated push_cmd_pkt parameter type

### DIFF
--- a/usrp3/sim/rfnoc/sim_rfnoc_lib.svh
+++ b/usrp3/sim/rfnoc/sim_rfnoc_lib.svh
@@ -459,7 +459,7 @@ interface rfnoc_block_streamer #(
   // Args:
   // - cmd_pkt:  Command CVITA packet
   task automatic push_cmd_pkt (
-    output cvita_pkt_t cmd_pkt);
+    input cvita_pkt_t cmd_pkt);
     begin
       m_cvita_cmd.push_pkt(cmd_pkt);
     end


### PR DESCRIPTION
The parameter cmd_pkt on the function should be an input as otherwise the function can not be used to "push" packets.