### PR TITLE
Fix DDS DC offset

### DIFF
--- a/usrp3/lib/ip/complex_multiplier_dds/complex_multiplier_dds.xci
+++ b/usrp3/lib/ip/complex_multiplier_dds/complex_multiplier_dds.xci
@@ -21,7 +21,7 @@
         <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_DOUT.HAS_TSTRB">0</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_DOUT.LAYERED_METADATA">undef</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_DOUT.PHASE">0.000</spirit:configurableElementValue>
-        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_DOUT.TDATA_NUM_BYTES">6</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_DOUT.TDATA_NUM_BYTES">8</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_DOUT.TDEST_WIDTH">0</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_DOUT.TID_WIDTH">0</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="BUSIFPARAM_VALUE.M_AXIS_DOUT.TUSER_WIDTH">0</spirit:configurableElementValue>
@@ -73,10 +73,10 @@
         <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_HAS_S_AXIS_CTRL_TUSER">0</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_LATENCY">7</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_MULT_TYPE">1</spirit:configurableElementValue>
-        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_M_AXIS_DOUT_TDATA_WIDTH">48</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_M_AXIS_DOUT_TDATA_WIDTH">64</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_M_AXIS_DOUT_TUSER_WIDTH">1</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_OPTIMIZE_GOAL">1</spirit:configurableElementValue>
-        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_OUT_WIDTH">24</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_OUT_WIDTH">32</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_S_AXIS_A_TDATA_WIDTH">48</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_S_AXIS_A_TUSER_WIDTH">1</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="MODELPARAM_VALUE.C_S_AXIS_B_TDATA_WIDTH">32</spirit:configurableElementValue>
@@ -112,7 +112,7 @@
         <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.MultType">Use_Mults</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.OptimizeGoal">Performance</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.OutTLASTBehv">Pass_A_TLAST</spirit:configurableElementValue>
-        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.OutputWidth">24</spirit:configurableElementValue>
+        <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.OutputWidth">32</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="PARAM_VALUE.RoundMode">Truncate</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.ARCHITECTURE">kintex7</spirit:configurableElementValue>
         <spirit:configurableElementValue spirit:referenceId="PROJECT_PARAM.BOARD"/>

--- a/usrp3/lib/rfnoc/dds_freq_tune.v
+++ b/usrp3/lib/rfnoc/dds_freq_tune.v
@@ -141,6 +141,10 @@ module dds_freq_tune  #(
   wire mult_in_b_tvalid;
   wire mult_in_b_tready;
   wire mult_in_b_tlast; //no connect
+  wire [2*32-1:0] mult_out_tdata;
+  wire mult_out_tvalid;
+  wire mult_out_tready;
+  wire mult_out_tlast;
 
   axi_sync #(
     .SIZE(2),
@@ -170,11 +174,26 @@ module dds_freq_tune  #(
     .s_axis_b_tready(mult_in_b_tready),        // output wire s_axis_b_tready
     .s_axis_b_tlast(mult_in_b_tlast),        // output wire s_axis_b_tlast
     .s_axis_b_tdata(mult_in_b_tdata),          // input wire [31 : 0] s_axis_b_tdata
-    .m_axis_dout_tvalid(m_axis_dout_tvalid),  // output wire m_axis_dout_tvalid
-    .m_axis_dout_tready(m_axis_dout_tready),  // input wire m_axis_dout_tready
-    .m_axis_dout_tlast(m_axis_dout_tlast),    // output wire m_axis_dout_tlast
-    .m_axis_dout_tdata(m_axis_dout_tdata)    // output wire [47 : 0] m_axis_dout_tdata
+    .m_axis_dout_tvalid(mult_out_tvalid),  // output wire m_axis_dout_tvalid
+    .m_axis_dout_tready(mult_out_tready),  // input wire m_axis_dout_tready
+    .m_axis_dout_tlast(mult_out_tlast),    // output wire m_axis_dout_tlast
+    .m_axis_dout_tdata(mult_out_tdata)    // output wire [63 : 0] m_axis_dout_tdata
   );
+
+  axi_round_complex #(
+    .WIDTH_IN(32),
+    .WIDTH_OUT(OUTPUT_WIDTH))
+  axi_round_complex_inst (
+    .clk(clk),
+    .reset(reset | reset_reg),
+    .i_tdata(mult_out_tdata),
+    .i_tlast(mult_out_tlast),
+    .i_tvalid(mult_out_tvalid),
+    .i_tready(mult_out_tready),
+    .o_tdata(m_axis_dout_tdata),
+    .o_tlast(m_axis_dout_tlast),
+    .o_tvalid(m_axis_dout_tvalid),
+    .o_tready(m_axis_dout_tready));
 
   //debug
   assign state_out = state;


### PR DESCRIPTION
Related issue: EttusResearch/uhd#211

The DDS's complex multiplier was originally set to truncate the output to 24 bits. Truncation generally introduces a negative 0.5 bit bias, which shows up as a DC offset. To fix the issue, I instead set it to truncate to 32 bits and used axi_round to round to 24 bits. While I could have truncated to only 25 bits, using 32 bits allows more range for the OUTPUT_WIDTH parameter at no additional increase in resource utilization.

The fix can be verified by running the rfnoc_ddc.grc flowgraph in gr-ettus with the default settings. Note that the effect appears smaller in this flowgraph than in my issue due to the level of the added noise.

Before:

![with_dc_offset](https://user-images.githubusercontent.com/951880/50565792-d9ec7d80-0d75-11e9-9aa6-ed64db02a1be.png)

After:

![without_dc_offset](https://user-images.githubusercontent.com/951880/50565826-49626d00-0d76-11e9-89a3-3a38518aadde.png)

Bitstream with fix: [bitstream.tar.gz](https://github.com/EttusResearch/fpga/files/2718804/bitstream.tar.gz)

