### PR TITLE
Allow SystemVerilog source files

### DIFF
--- a/usrp3/tools/scripts/viv_generate_bd.tcl
+++ b/usrp3/tools/scripts/viv_generate_bd.tcl
@@ -38,7 +38,7 @@ foreach src_file $hdl_sources {
     if [expr [lsearch {.vhd .vhdl} $hdl_ext] >= 0] {
         puts "BUILDER: Adding VHDL    : $src_file"
         read_vhdl -library work $src_file
-    } elseif [expr [lsearch {.v .vh} $hdl_ext] >= 0] {
+    } elseif [expr [lsearch {.v .sv .vh .svh} $hdl_ext] >= 0] {
         puts "BUILDER: Adding Verilog : $src_file"
         read_verilog $src_file
     } else {

--- a/usrp3/tools/scripts/viv_utils.tcl
+++ b/usrp3/tools/scripts/viv_utils.tcl
@@ -64,7 +64,7 @@ proc ::vivado_utils::initialize_project { {save_to_disk 0} } {
         if [expr [lsearch {.vhd .vhdl} $src_ext] >= 0] {
             puts "BUILDER: Adding VHDL    : $src_file"
             read_vhdl -library work $src_file
-        } elseif [expr [lsearch {.v .vh} $src_ext] >= 0] {
+        } elseif [expr [lsearch {.v .vh .sv .svh} $src_ext] >= 0] {
             puts "BUILDER: Adding Verilog : $src_file"
             read_verilog $src_file
         } elseif [expr [lsearch {.xdc} $src_ext] >= 0] {


### PR DESCRIPTION
Crawl .sv and .svh source files during project generation. Allows use of SystemVerilog in source.