### PR TITLE
uhd_image_builder: Let the OOT selection point to folders that arent named "rfnoc"

### DIFF
--- a/usrp3/tools/scripts/uhd_image_builder.py
+++ b/usrp3/tools/scripts/uhd_image_builder.py
@@ -303,18 +303,24 @@ def create_oot_include(device, include_dirs):
             currpath = os.path.abspath(str(dirs))
             if os.path.isdir(currpath) & (os.path.basename(currpath) == "rfnoc"):
                 # Case 1: Pointed directly to rfnoc directory
-                oot_path = os.path.dirname(currpath)
+                oot_path = currpath
             elif os.path.isdir(os.path.join(currpath, 'rfnoc')):
                 # Case 2: Pointed to top level rfnoc module directory
+                oot_path = os.path.join(currpath, 'rfnoc')
+            elif os.path.isfile(os.path.join(currpath, 'Makefile.inc')):
+                # Case 3: Pointed to a random directory with a Makefile.inc
                 oot_path = currpath
             else:
                 print('No RFNoC module found at ' + os.path.abspath(currpath))
                 continue
             if oot_path not in oot_dir_list:
                 oot_dir_list.append(oot_path)
-                named_path = os.path.join('$(BASE_DIR)', get_relative_path(get_basedir(), oot_path), 'rfnoc')
+                named_path = os.path.join('$(BASE_DIR)', get_relative_path(get_basedir(), oot_path))
                 incfile.write(OOT_DIR_TMPL.format(oot_dir=named_path))
-                if os.path.isfile(os.path.join(oot_path, 'rfnoc', 'Makefile.inc')):
+                if os.path.isfile(os.path.join(oot_path, 'Makefile.inc')):
+                    # Check for Makefile.inc
+                    incfile.write(OOT_INC_TMPL)
+                elif os.path.isfile(os.path.join(oot_path, 'rfnoc', 'Makefile.inc')):
                     # Check for Makefile.inc
                     incfile.write(OOT_INC_TMPL)
                 elif os.path.isfile(os.path.join(oot_path, 'rfnoc', 'fpga-src', 'Makefile.srcs')):


### PR DESCRIPTION
This PR adds a mode of the OOT module selection process that simply searches for a Makefile.inc file, rather than checking the directory name is "rfnoc".

Example usage: Point to *subfolders* inside an OOT module, such that an FPGA build only needs to regenerate the IP required for a particular noc_block rather than for everything in the OOT module. For example, this "dsp-utils" folder can be located as an OOT module, 
 without building any other IP in the project: https://gitlab.com/theseus-cores/theseus-cores/tree/master/fpga-rfnoc/dsp-utils 

I wouldnt anticipate any backwards-compatibility issues here, and I've been using this successfully for a few months now.