### PR TITLE
n3xx/e3xx: Fix arbitration of tx DMA to guarantee contiguous packets

### DIFF
--- a/usrp3/top/e31x/ip/e31x_ps_bd/chdr_dma_tx.tcl
+++ b/usrp3/top/e31x/ip/e31x_ps_bd/chdr_dma_tx.tcl
@@ -65,6 +65,7 @@ proc create_hier_cell_tx_dma { parentCell nameHier numPorts } {
   set axis_interconnect_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axis_interconnect:2.1 axis_interconnect_0 ]
   set_property -dict [ list \
      CONFIG.ARB_ON_TLAST {1} \
+     CONFIG.ARB_ON_MAX_XFERS {0} \
      CONFIG.ENABLE_ADVANCED_OPTIONS {1} \
      CONFIG.M00_HAS_REGSLICE {1} \
      CONFIG.NUM_MI {1} \

--- a/usrp3/top/e320/ip/e320_ps_bd/chdr_dma_tx.tcl
+++ b/usrp3/top/e320/ip/e320_ps_bd/chdr_dma_tx.tcl
@@ -65,6 +65,7 @@ proc create_hier_cell_tx_dma { parentCell nameHier numPorts } {
   set axis_interconnect_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axis_interconnect:2.1 axis_interconnect_0 ]
   set_property -dict [ list \
      CONFIG.ARB_ON_TLAST {1} \
+     CONFIG.ARB_ON_MAX_XFERS {0} \
      CONFIG.ENABLE_ADVANCED_OPTIONS {1} \
      CONFIG.M00_HAS_REGSLICE {1} \
      CONFIG.NUM_MI {1} \

--- a/usrp3/top/n3xx/ip/n310_ps_bd/chdr_dma_tx.tcl
+++ b/usrp3/top/n3xx/ip/n310_ps_bd/chdr_dma_tx.tcl
@@ -65,6 +65,7 @@ proc create_hier_cell_tx_dma { parentCell nameHier numPorts } {
   set axis_interconnect_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:axis_interconnect:2.1 axis_interconnect_0 ]
   set_property -dict [ list \
      CONFIG.ARB_ON_TLAST {1} \
+     CONFIG.ARB_ON_MAX_XFERS {0} \
      CONFIG.ENABLE_ADVANCED_OPTIONS {1} \
      CONFIG.M00_HAS_REGSLICE {1} \
      CONFIG.NUM_MI {1} \


### PR DESCRIPTION
See https://github.com/EttusResearch/uhd/issues/296 for discussion of issue - this fix should ensure the RFNoC crossbar is only fed full contiguous CHDR packets. 

Downside is its now possible for the interconnect to be permanently locked if it never receives a tlast. There is an option to arbitrate on number of low tvalid cycles but IMO it seems like you'd rather wait and hope the dma eventually asserts tlast.