### PR TITLE
hls: Use tcl to glob HLS *.v and *.dat outputs

### DIFF
--- a/usrp3/lib/hls/addsub_hls/Makefile.inc
+++ b/usrp3/lib/hls/addsub_hls/Makefile.inc
@@ -6,16 +6,14 @@
 #
 
 # Add C/C++/tcl files relative to usrp3/lib/hls/<ip> directory
-HLS_IP_ADDSUB_HLS_SRCS = \
+HLS_IP_ADDSUB_HLS_LIB_SRCS = $(addprefix $(HLS_IP_DIR)/addsub_hls/, \
 addsub_hls.cpp \
-addsub_hls.tcl
-
-HLS_IP_ADDSUB_HLS_OUTS = $(addprefix $(IP_BUILD_DIR)/addsub_hls/, \
-solution/impl/verilog/addsub_hls.v \
+addsub_hls.tcl \
 )
 
-# Sources in lib directory
-HLS_IP_ADDSUB_HLS_LIB_SRCS = $(addprefix $(HLS_IP_DIR)/addsub_hls/, $(HLS_IP_ADDSUB_HLS_SRCS))
+# HLS output artifact points to the ip/hdl/verilog folder
+# When adding files to vivado, glob for *.v and *.dat to ingest all generated outputs
+HLS_IP_ADDSUB_HLS_OUTS = $(IP_BUILD_DIR)/addsub_hls/solution/impl/ip/hdl/verilog
 
 # Build with HLS
 $(HLS_IP_ADDSUB_HLS_OUTS) : $(HLS_IP_ADDSUB_HLS_LIB_SRCS)

--- a/usrp3/tools/scripts/viv_sim_project.tcl
+++ b/usrp3/tools/scripts/viv_sim_project.tcl
@@ -60,12 +60,20 @@ foreach src_file $design_srcs {
     } elseif [expr [lsearch {.ngc .edif} $src_ext] >= 0] {
         puts "BUILDER: Adding Netlist : $src_file"
         read_edif $src_file
+    } elseif [expr [lsearch {.dat} $src_ext] >= 0] {
+        puts "BUILDER: Adding Data File : $src_file"
+        add_files -fileset $sim_fileset -norecurse $src_file
     } elseif [expr [lsearch {.bd} $src_ext] >= 0] {
-            puts "BUILDER: Adding Block Diagram: $src_file"
-            add_files -norecurse $src_file
+        puts "BUILDER: Adding Block Diagram: $src_file"
+        add_files -norecurse $src_file
     } elseif [expr [lsearch {.bxml} $src_ext] >= 0] {
-            puts "BUILDER: Adding Block Diagram XML: $src_file"
-            add_files -norecurse $src_file
+        puts "BUILDER: Adding Block Diagram XML: $src_file"
+        add_files -norecurse $src_file
+    } elseif [expr [string equal $src_ext ""] == 1] {
+        puts "BUILDER: Adding Folder Glob : $src_file"
+        set glob_all [glob $src_file/*.*]
+        puts "BUILDER: Globbed Files : $glob_all"
+        add_files $glob_all
     } else {
         puts "BUILDER: \[WARNING\] File ignored!!!: $src_file"
     }

--- a/usrp3/tools/scripts/viv_utils.tcl
+++ b/usrp3/tools/scripts/viv_utils.tcl
@@ -86,6 +86,11 @@ proc ::vivado_utils::initialize_project { {save_to_disk 0} } {
         } elseif [expr [lsearch {.dat} $src_ext] >= 0] {
             puts "BUILDER: Adding Data File : $src_file"
             add_files $src_file
+        } elseif [expr [string equal $src_ext ""] == 1] {
+            puts "BUILDER: Adding Folder Glob : $src_file"
+            set glob_all [glob $src_file/*.*]
+            puts "BUILDER: Globbed Files : $glob_all"
+            add_files $glob_all
         } else {
             puts "BUILDER: \[WARNING\] File ignored!!!: $src_file"
         }


### PR DESCRIPTION
The commit 615d9b8e removed a pretty critical HLS feature that
would automatically find *.v, *.dat files to add to the build.
HLS outputs are often weirdly named with limited correlation
to the original filename, and they may change based on updates
to the C code or even updates to Vivado! So the HLS output file
finding HAS to be dynamic... Unfortunately it turns out Makefiles
are really bad at using wildcards in variables, so this commit
delegates the globbing to the simulation and build vivado tcl script.

Now, in `viv_sim_project.tcl` and `viv_utils.tcl`, a src_file
with no extension is treated as a folder where we want to add all
subfiles (in the case of HLS outputs, this would be verilog files
and dat files).

These change keeps the same idea as in 615d9b8e, which is to
say each build only generates the HLS outputs as needed, similar
to the IP build process.

Here's an example of a particularly nasty HLS output folder. All
files here *have* be included in the VIV_DESIGN_SRCS in order
to build correctly...

```
$ ls build-ip/xc7z020clg484-2/he360_fll_postfft/solution/impl/ip/hdl/verilog/
Block_arrayctor_loop_1.v  he360_fll_postfftfYi.v          run_ap_fixed_1.v
Block_arrayctor_loop_2.v  he360_fll_postfftg8j_memcore.v  run_ap_fixed_s_abdEe.v
Block_arrayctor_loop.v    he360_fll_postfftg8j.v          run_ap_fixed_s_ffbkb_ram.v
fifo_w18_d2_A.v           he360_fll_postfft.v             run_ap_fixed_s_ffbkb.v
fifo_w31_d2_A.v           Loop_OutputLoop_proc.v          run_ap_fixed_s_ffcud_rom.dat
fifo_w32_d2_A.v           phase_accum_loop.v              run_ap_fixed_s_ffcud.v
he360_fll_postffteOg.v    quadratic_freq_estim.v          run_ap_fixed_s.v
```