### PR TITLE
uhd_image_builder: Fix a bad OOT-module path creation for Makefile.srcs

### DIFF
--- a/usrp3/tools/scripts/uhd_image_builder.py
+++ b/usrp3/tools/scripts/uhd_image_builder.py
@@ -323,11 +323,11 @@ def create_oot_include(device, include_dirs):
                 elif os.path.isfile(os.path.join(oot_path, 'rfnoc', 'Makefile.inc')):
                     # Check for Makefile.inc
                     incfile.write(OOT_INC_TMPL)
-                elif os.path.isfile(os.path.join(oot_path, 'rfnoc', 'fpga-src', 'Makefile.srcs')):
+                elif os.path.isfile(os.path.join(oot_path, 'fpga-src', 'Makefile.srcs')):
                     # Legacy: Check for fpga-src/Makefile.srcs
                     # Read, then append to file
-                    curr_srcs = open(os.path.join(oot_path, 'rfnoc', 'fpga-src', 'Makefile.srcs'), 'r').read()
-                    curr_srcs = curr_srcs.replace('SOURCES_PATH', os.path.join(oot_path, 'rfnoc', 'fpga-src', ''))
+                    curr_srcs = open(os.path.join(oot_path, 'fpga-src', 'Makefile.srcs'), 'r').read()
+                    curr_srcs = curr_srcs.replace('SOURCES_PATH', os.path.join(oot_path, 'fpga-src', ''))
                     incfile.write(OOT_SRCS_TMPL.format(sources=curr_srcs))
                 else:
                     print('No valid makefile found at ' + os.path.abspath(currpath))


### PR DESCRIPTION
Accidentally introduced in ef2fe801